### PR TITLE
Allowing unbounded depth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-serde_json = "1.0"
+serde_json = {version = "1.0", features = ["unbounded_depth"]}
 serde-transcode = "1.0"
 clap = "~2.31"
 error-chain = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "1024"]
-
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File};
 use std::io::{self, BufReader, BufWriter, Read};
@@ -34,6 +32,9 @@ fn prettify<S: Read, F: serde_json::ser::Formatter>(source: S, formatter: F) -> 
     let writer = BufWriter::new(io::stdout());
 
     let mut deserializer = serde_json::Deserializer::from_reader(source);
+
+    deserializer.disable_recursion_limit();
+
     let mut serializer = serde_json::Serializer::with_formatter(writer, formatter);
     serde_transcode::transcode(&mut deserializer, &mut serializer)?;
     Ok(())


### PR DESCRIPTION
Using the `unbounded_depth` feature of serde-json to allow unbounded recursion depth for deep JSON files.